### PR TITLE
feat: Icon Button

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps } from "react";
 
-import { Container } from "./style";
+import { Container, IconButton } from "./style";
 
 export type Variant = "solid" | "outline";
 export type Color = "primary" | "neutral";
@@ -10,15 +10,18 @@ export interface ButtonProps extends ComponentProps<"button"> {
   $variant?: Variant;
   color?: Color;
   size?: Size;
+  iconOnly?: boolean;
 }
 
 export default function Button({
   $variant = "solid",
   color = "primary",
   size = "md",
+  iconOnly = false,
   children,
   ...props
 }: ButtonProps) {
+  if (iconOnly) return <IconButton>{children}</IconButton>;
   return (
     <Container $variant={$variant} color={color} size={size} {...props}>
       {children}

--- a/src/components/Button/style.ts
+++ b/src/components/Button/style.ts
@@ -75,3 +75,12 @@ export const Container = styled.button<
     }
   `}
 `;
+
+export const IconButton = styled.button`
+  all: initial;
+  width: fit-content;
+  height: fit-content;
+  svg {
+    display: block;
+  }
+`;


### PR DESCRIPTION
## 📝 개요

아이콘만 있는 버튼(아이콘 사이즈와 동일한 크기의 버튼) 타입 추가했습니다.

![image](https://github.com/imdaxsz/orday-front-end/assets/80813703/9a758dd7-0991-4f81-87b7-15064ef7c397)

```
  <Button iconOnly>
    <AiOutlinePlus />
  </Button>
```

기존 Button에 iconOnly props를 추가하고 children으로 아이콘 svg 넣어주시면 됩니다.

## 🚀 변경사항


## 🔗 관련 이슈

#10

## ➕ 기타

의견 있으시면 코멘트 남겨주세요~~

