### PR TITLE
feat: 브랜드 상세 페이지 1차 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { ThemeProvider } from "styled-components";
 import theme from "@/styles/theme";
 
 import Layout from "./components/Layout";
+import BrandDetail from "./routes/Brand/Detail";
+import BrandList from "./routes/Brand/List";
 import Home from "./routes/Home";
 import GlobalStyle from "./styles/GlobalStyle";
 
@@ -15,6 +17,8 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Layout />}>
             <Route path="" element={<Home />} />
+            <Route path="brands" element={<BrandList />} />
+            <Route path="brands/:name" element={<BrandDetail />} />
           </Route>
         </Routes>
       </ThemeProvider>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -21,7 +21,7 @@ export default function Button({
   children,
   ...props
 }: ButtonProps) {
-  if (iconOnly) return <IconButton>{children}</IconButton>;
+  if (iconOnly) return <IconButton {...props}>{children}</IconButton>;
   return (
     <Container $variant={$variant} color={color} size={size} {...props}>
       {children}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,14 +4,14 @@ import styled from "styled-components";
 
 import Menu from "./Menu";
 
-const Container = styled.div<{ $isHome: boolean }>`
+const Container = styled.div<{ $hasBorder: boolean }>`
   width: 100%;
   height: 70px;
   background-color: white;
   padding: 15px 30px;
   border-bottom: solid 1px
-    ${({ $isHome, theme }) =>
-      $isHome ? "white" : theme.colors["primary"]["60"]};
+    ${({ $hasBorder, theme }) =>
+      $hasBorder ? "white" : theme.colors["primary"]["60"]};
   position: relative;
 `;
 
@@ -41,10 +41,12 @@ const Item = styled.li`
 
 export default function Header() {
   const [menuIsVisible, setMenuIsVisible] = useState(false);
-  const pathname = useLocation().pathname.split("/")[1];
-  const isHome = pathname === "";
+  const pathname = useLocation().pathname.split("/");
+  // 랜딩 페이지, 브랜드 상세 페이지에서만 border bottom 제거
+  const hasBorder =
+    pathname[1] === "" || (pathname[1] === "brands" && Boolean(pathname[2]));
   return (
-    <Container $isHome={isHome}>
+    <Container $hasBorder={hasBorder}>
       <Content>
         <Group>
           <Item onClick={() => setMenuIsVisible((prev) => !prev)}>SHOP</Item>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ import Header from "./Header";
 
 const Container = styled.div`
   width: 1280px;
-  height: 100%;
+  min-height: 100%;
   margin: 0 auto;
 `;
 

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -2,17 +2,24 @@ import { useState } from "react";
 import { PiHeartBold, PiHeartFill } from "react-icons/pi";
 import styled from "styled-components";
 
-export default function LikeButton() {
+/**
+ * @description 좋아요 기능 적용 가능 대상
+ */
+type LikeTarget = "product" | "brand" | "post";
+
+export default function LikeButton({ target }: { target: LikeTarget }) {
   const [like, setLike] = useState(false);
-  const handleClick = () => {
+  const handlerClick = () => {
     setLike((prev) => !prev);
+    console.log(target); // 임시
+    // TODO 서버 요청
   };
 
   // TODO
-  // 서버에서 사용자가 좋아요 한 상품인지 확인
+  // 서버에서 사용자가 좋아요 한 상품 또는 브랜드인지 확인
 
   return (
-    <Container onClick={handleClick}>
+    <Container onClick={handlerClick}>
       {like ? <PiHeartFill /> : <PiHeartBold />}
     </Container>
   );

--- a/src/components/ProductCard/index.tsx
+++ b/src/components/ProductCard/index.tsx
@@ -1,8 +1,8 @@
 import BestTag from "@/assets/best.svg?react";
 import NewTag from "@/assets/new.svg?react";
+import LikeButton from "@/components/LikeButton";
 import { ProductInfo } from "@/types";
 
-import LikeButton from "./LikeButton";
 import RemoveButton from "./RemoveButton";
 import {
   Brand,
@@ -36,7 +36,7 @@ export default function ProductCard({
           <>
             {$tag === "NEW" && <NewTag />}
             {$tag === "BEST" && <BestTag />}
-            <LikeButton />
+            <LikeButton target="product" />
           </>
         ) : (
           <RemoveButton />

--- a/src/routes/Brand/Detail.tsx
+++ b/src/routes/Brand/Detail.tsx
@@ -1,4 +1,5 @@
 import { IoArrowBackOutline } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import Button from "@/components/Button";
@@ -7,6 +8,7 @@ import ProductCard from "@/components/ProductCard";
 import { ProductInfo } from "@/types";
 
 export default function BrandDetail() {
+  const navigate = useNavigate();
   const productMockData: ProductInfo = {
     image:
       "https://image.msscdn.net/images/goods_img/20230323/3174776/3174776_16795542598248_big.png",
@@ -20,7 +22,7 @@ export default function BrandDetail() {
   return (
     <div style={{ paddingBottom: "150px" }}>
       <Header>
-        <Button iconOnly>
+        <Button iconOnly onClick={() => navigate(-1)}>
           <IoArrowBackOutline size={24} />
         </Button>
         <LikeButton target="brand" />
@@ -40,9 +42,11 @@ const Header = styled.div`
   height: 250px;
   background: rgba(0, 0, 0, 0.3);
   position: relative;
+
   button {
     position: absolute;
     z-index: 200;
+    cursor: pointer;
   }
 
   & > button:first-of-type {

--- a/src/routes/Brand/Detail.tsx
+++ b/src/routes/Brand/Detail.tsx
@@ -1,0 +1,76 @@
+import { IoArrowBackOutline } from "react-icons/io5";
+import styled from "styled-components";
+
+import Button from "@/components/Button";
+import LikeButton from "@/components/LikeButton";
+import ProductCard from "@/components/ProductCard";
+import { ProductInfo } from "@/types";
+
+export default function BrandDetail() {
+  const productMockData: ProductInfo = {
+    image:
+      "https://image.msscdn.net/images/goods_img/20230323/3174776/3174776_16795542598248_big.png",
+    url: "",
+    brand: "플라스틱 아크",
+    name: "팻볼 [FB-F1-05]",
+    price: 74000,
+  };
+  const productsMockData: ProductInfo[] = Array(4).fill(productMockData);
+
+  return (
+    <div style={{ paddingBottom: "150px" }}>
+      <Header>
+        <Button iconOnly>
+          <IoArrowBackOutline size={24} />
+        </Button>
+        <LikeButton target="brand" />
+        <BackgroundImage src="https://s3-alpha-sig.figma.com/img/cf7c/e3f4/d7a8698a8182ae23145a875332ba5172?Expires=1696204800&Signature=L2dz-XfbV9p0do4TdZXDszmaadl5Dzu-OXy161x-4am7U57ZOHIqf~ZG4crzJTrsM13JoC84RNvnARYr1M-SqtH8CaGMdmTb6PPtF4OLiabCDy2jnyL84iBJy6drFiwNFQm6OH026biZE5yuVdA1iDDYccYuHAGjzdYtR-pALYqo42jUmZrnHyeKy5drIiF40H4hfsAx-bBLtOHtr1jcPWVniTNckeVPCyxAVFGZ3oIUgPC~YS0CQFYwFBquw3WTIn~xTwmQSwDOKnICNZqE6AnOZhX1~PhxELIwMAsS~6mD1k-92rimEk8YduA8I2pIzr0kK2pOlYDRKc5kZzWoXA__&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4" />
+      </Header>
+      <Items>
+        {productsMockData.map((product, i) => (
+          <ProductCard key={i} size="md" $tag="NEW" info={product} />
+        ))}
+      </Items>
+    </div>
+  );
+}
+
+const Header = styled.div`
+  width: 100%;
+  height: 250px;
+  background: rgba(0, 0, 0, 0.3);
+  position: relative;
+  button {
+    position: absolute;
+    z-index: 200;
+  }
+
+  & > button:first-of-type {
+    top: 18px;
+    left: 26px;
+  }
+
+  & > button:last-of-type {
+    top: 18.75px;
+    right: 28px;
+    svg {
+      width: 24px;
+      height: 24px;
+    }
+  }
+`;
+
+const BackgroundImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const Items = styled.div`
+  width: fit-content;
+  height: fit-content;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin: 50px auto;
+`;

--- a/src/routes/Brand/List.tsx
+++ b/src/routes/Brand/List.tsx
@@ -1,0 +1,3 @@
+export default function BrandList() {
+  return <div>브랜드 전체 리스트 페이지</div>;
+}


### PR DESCRIPTION
## 📝 개요

브랜드 상세 페이지 퍼블리싱

![screencapture](https://github.com/imdaxsz/orday-front-end/assets/80813703/0b12603f-ac17-4988-ad9e-e7c8cb83c04b)


## 🚀 변경사항

### LikeButton.tsx
- 컴포넌트 파일이 ```ProductCard -> Components``` 폴더로 이동되었습니다.
- 좋아요 대상(상품, 브랜드, 게시물)을 props로 추가하여 재사용성을 개선했습니다.

### Button
- 아이콘 버튼에 onClick을 포함한 버튼 기본 props 누락된 부분 추가했습니다.

## 🔗 관련 이슈

#7 #24

## ➕ 기타

하위 카테고리 메뉴 및 드롭다운은 모카님이 작업중이셔서 추후에 추가하겠습니다!

<br/>
