### PR TITLE
feat: 회원 리뷰 리스트 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Login from "./routes/Login";
 import MyPage from "./routes/MyPage";
 import Order from "./routes/Order";
 import GuestOrder from "./routes/Order/GuestOrder";
+import MyReviewList from "./routes/Review/List";
 import GlobalStyle from "./styles/GlobalStyle";
 
 export default function App() {
@@ -37,6 +38,7 @@ export default function App() {
             <Route path="order/guest" element={<GuestOrder />} />
             <Route path="like/brands" element={<LikeBrandList />} />
             <Route path="/myPage" element={<MyPage />} />
+            <Route path="/myPage/reviews" element={<MyReviewList />} />
             <Route path="cart" element={<Cart />} />
           </Route>
           <Route path="/login" element={<Login />} />

--- a/src/components/ReviewItem/index.tsx
+++ b/src/components/ReviewItem/index.tsx
@@ -1,0 +1,86 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+import Button from "../Button";
+
+interface Props {
+  status: "WRITABLE" | "WRITTEN";
+  orderNo: string;
+  productInfo: {
+    id: string;
+    image: string;
+    name: string;
+  };
+}
+
+export default function ReviewItem({ status, orderNo, productInfo }: Props) {
+  return (
+    <Container>
+      <Header>
+        <h3>{status === "WRITABLE" ? "작성가능" : "작성완료"}</h3>
+        <p>{orderNo}</p>
+      </Header>
+      <Content>
+        <Link to={`/products/${productInfo.id}`}>
+          <img src={productInfo.image} alt={productInfo.name} />
+        </Link>
+        <h4>{productInfo.name}</h4>
+        <Button>{status === "WRITABLE" ? "작성하기" : "수정하기"}</Button>
+      </Content>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+  padding: 30px 0;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  height: 27px;
+
+  h3 {
+    color: ${({ theme }) => theme.colors["primary"]["80"]};
+  }
+
+  p {
+    color: ${({ theme }) => theme.colors["neutral"]["40"]};
+  }
+`;
+
+const Content = styled.div`
+  display: flex;
+  gap: 30px;
+
+  img {
+    display: block;
+    width: 100px;
+    height: 100px;
+    flex-shrink: 0;
+    border-radius: 10px;
+    border: 1px solid #aeaeae;
+    background-color: ${({ theme }) => theme.colors["neutral"]["10"]};
+  }
+
+  h4 {
+    ${({ theme }) => theme.typo["body-2-b"]};
+    line-height: 170%;
+    height: fit-content;
+    margin-top: 15px;
+    width: 100%;
+  }
+
+  button {
+    width: 88px;
+    height: 36px;
+    ${({ theme }) => theme.typo["body-2-b"]};
+    padding: 10px 14px;
+    margin-top: 64px;
+    flex-shrink: 0;
+  }
+`;

--- a/src/routes/Review/List.tsx
+++ b/src/routes/Review/List.tsx
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+import BackButton from "@/components/BackButton";
+import ReviewItem from "@/components/ReviewItem";
+import Tabs, { Tab } from "@/components/Tabs";
+
+export default function MyReviewList() {
+  const ProductMockData = {
+    id: "1",
+    image: "",
+    name: "파타고니아 레트로 X 양털 후리스 뽀글이 플리스 자켓",
+  };
+
+  return (
+    <Container>
+      <BackButton pageTitle="리뷰 작성/수정" />
+      <LikeTabs>
+        <Tab value={1} label="작성가능 리뷰" />
+        <Tab value={2} label="작성한 리뷰" />
+      </LikeTabs>
+      <ReviewItem
+        status="WRITABLE"
+        orderNo="0000001"
+        productInfo={ProductMockData}
+      />
+      <ReviewItem
+        status="WRITABLE"
+        orderNo="0000002"
+        productInfo={ProductMockData}
+      />
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: 722px;
+  margin: 0 auto;
+  padding-bottom: 100px;
+`;
+
+const LikeTabs = styled(Tabs)`
+  margin: 30px auto 0;
+  height: 52px;
+  & > li {
+    color: ${({ theme }) => theme.colors["neutral"]["100"]};
+  }
+`;


### PR DESCRIPTION
## 📝 개요

마이페이지 내 회원이 작성한 리뷰 리스트 조회 페이지 퍼블리싱

 
- 작성 가능
![1](https://github.com/imdaxsz/orday-front-end/assets/80813703/87a13466-b130-4e51-bf2a-d998243104e1)

- 작성 완료
![2](https://github.com/imdaxsz/orday-front-end/assets/80813703/4fe76320-9240-4e62-a0ec-1e7ae9add6b7)


## 🚀 변경사항

- 라우터 추가
```/myPage/reviews```

## 🔗 관련 이슈

#70

## ➕ 기타

여긴 그냥 url 안 나누고 탭으로 내용만 바꿀 것 같네요..!
탭 전환 했을 때 내용 바뀌는 건 api 작업할 때 할 것 같습니다.
