### PR TITLE
refactor: 구글 로그인 및 axios interceptor 로직 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import Logo from "@/assets/logo.svg?react";
-// import { useAppSelector } from "@/store";
 
 import Backdrop from "../Backdrop";
 import Menu from "../Menu";
@@ -13,7 +12,7 @@ import { Container, Content, Group, Item } from "./style";
 export default function Header() {
   const [menuIsVisible, setMenuIsVisible] = useState(false);
   const [myMenuIsVisible, setMyMenuIsVisible] = useState(false);
-  // const isLoggedIn = useAppSelector((state) => state.auth.accessToken);
+
   const isLoggedIn = localStorage.getItem("token");
   const navigate = useNavigate();
   const location = useLocation();

--- a/src/libs/api/index.ts
+++ b/src/libs/api/index.ts
@@ -1,8 +1,5 @@
 import axios from "axios";
 
-import store from "@/store";
-import { setAccessToken, signout } from "@/store/slices/authSlice";
-
 import { ApiError, BaseError } from "../error";
 
 const instance = axios.create({
@@ -14,10 +11,10 @@ const instance = axios.create({
 // Request interceptor
 instance.interceptors.request.use((config) => {
   if (!config.headers) return config;
-  // redux store에서 accesstoken 가져오기
-  const accesstoken = store.getState().auth.accessToken;
-  if (accesstoken && config.headers) {
-    config.headers["authorization"] = `Bearer ${accesstoken}`;
+  // access token 가져오기
+  const accessToken = localStorage.getItem("token");
+  if (accessToken && config.headers) {
+    config.headers["authorization"] = `Bearer ${accessToken}`;
   }
   return config;
 });
@@ -26,36 +23,20 @@ instance.interceptors.request.use((config) => {
 instance.interceptors.response.use(
   (response) => {
     // response header에 access token이 있다면
-    // access token이 (재)발급된 걸로 간주 -> redux store에 저장
+    // access token이 (재)발급된 걸로 간주 -> localStorage에 저장
     const accessToken = response.headers["authorization"];
-    if (accessToken) store.dispatch(setAccessToken(accessToken));
-    // refresh token이 있다면 localstorage에 저장
-    const refreshToken = response.headers["authorization-refresh"];
-    if (refreshToken) localStorage.setItem("token", refreshToken);
+    if (accessToken) localStorage.setItem("token", accessToken);
     // 토큰이 요청 중에 재발급된 경우 기존 요청 재요청
-    if (response.status === 201 && accessToken && refreshToken) {
+    if (response.status === 201 && accessToken) {
       response.config.headers["authorization"] = accessToken;
-      delete response.config.headers["authorization-refresh"];
       return instance(response.config);
     }
     return response.data;
   },
   (error) => {
     if (error.response?.status === 401) {
-      console.log(error);
-      const originalRequest = error.config;
-      // access token 만료인 경우(요청 헤더에 access token만 있었던 경우)
-      if (!originalRequest.headers["authorization-refresh"]) {
-        // refresh 토큰과 함께 token 재발급 요청
-        const refreshToken = localStorage.getItem("token");
-        originalRequest.headers[
-          "authorization-refresh"
-        ] = `Bearer ${refreshToken}`;
-        return instance(originalRequest);
-      }
-      // 모든 토큰 만료인 경우 (요청 헤더에 모든 토큰이 있었던 경우)
-      // 로그아웃 처리
-      store.dispatch(signout());
+      console.log(error, "unauthorized");
+      // access token 제거
       localStorage.removeItem("token");
       window.alert("로그인 해주세요!");
       window.location.href = "/login";

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -8,7 +8,6 @@ import Head from "@/components/Head";
 import Loader from "@/components/Loader";
 import TextInput from "@/components/TextInput";
 import useLogin from "@/hooks/useLogin";
-// import { get } from "@/libs/api";
 
 export default function Login() {
   const {
@@ -25,11 +24,8 @@ export default function Login() {
   if (isLoggedIn) return <Navigate to="/" replace />;
 
   const googleLogin = () => {
-    // get("login/oauth2/code/google", {
-    //   baseURL: import.meta.env.VITE_GOOGLE_ROOT,
-    // });
-    const BASE_URL = import.meta.env.VITE_GOOGLE_ROOT;
-    window.location.href = `${BASE_URL}/login/oauth2/code/google`;
+    const BASE_URL = import.meta.env.VITE_API_ROOT;
+    window.location.href = `${BASE_URL}oauth2/authorization/google`;
   };
 
   return (

--- a/src/routes/router/privateRoutes.tsx
+++ b/src/routes/router/privateRoutes.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren, lazy } from "react";
 import { Navigate, RouteObject } from "react-router-dom";
 
 import Layout from "@/components/Layout";
-// import { useAppSelector } from "@/store";
 
 const Cart = lazy(() => import("@/routes/Cart"));
 const Order = lazy(() => import("@/routes/Order"));
@@ -17,10 +16,7 @@ const LikeList = lazy(() => import("@/routes/Like"));
 const LikeBrandList = lazy(() => import("@/routes/Like/Brand"));
 
 function PrivateRoute({ children }: PropsWithChildren) {
-  // 로그인 검증 (refresh token 확인)
-  // const isLoggedIn = useAppSelector((state) => state.auth.accessToken);
   const isLoggedIn = localStorage.getItem("token");
-  // const isLoggedIn = true;
   return isLoggedIn ? children : <Navigate to="/login" replace />;
 }
 

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,5 +1,9 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 
+/**
+ * @deprecated access token localStorage 저장으로 인해 더 이상 사용되지 않음
+ */
+
 interface AuthState {
   accessToken: string | null;
 }


### PR DESCRIPTION
## 📝 개요

구글 로그인 및 axios interceptor 로직 수정

## 🚀 변경사항

- refresh token을 쿠키에 저장하는 것으로 변경
- access token을 localStorage에 저장
- access token 전역 관리를 위해 존재했던 authSlice deprecated 처
- 토큰 저장 장소의 변동으로 인한 axios interceptor 수정

## 🔗 관련 이슈

#150

## ➕ 기타


