### PR TITLE
feat: api 예외 응답 타입 수정 및 예외 처리 추가

### DIFF
--- a/src/hooks/useEditProfile.ts
+++ b/src/hooks/useEditProfile.ts
@@ -129,6 +129,7 @@ export default function useEditProfile(option?: "join") {
           await updateUserInfo(updatedUserInfoItems);
           openModal();
         } catch (error) {
+          alert("오류가 발생했어요. 다시 시도해 주세요");
           console.log("Error updating user info: ", error);
         }
         setIsLoading(false);

--- a/src/hooks/useImageCompress.ts
+++ b/src/hooks/useImageCompress.ts
@@ -24,6 +24,7 @@ export default function useImageCompress() {
     } catch (error) {
       setIsLoading(false);
       console.log(error);
+      alert("이미지 압축 실패! 다시 시도해 주세요.");
     }
   };
 

--- a/src/hooks/useJoin.ts
+++ b/src/hooks/useJoin.ts
@@ -134,7 +134,7 @@ export default function useJoin() {
             setJoinError((prev) => ({ ...prev, result: 1 }));
           // 소셜 연동 가입 회원인 경우
           else setJoinError((prev) => ({ ...prev, result: 2 }));
-        }
+        } else alert("오류가 발생했어요. 다시 시도해 주세요");
         setIsLoading(false);
         console.log("Error join: ", error);
       }

--- a/src/hooks/useJoin.ts
+++ b/src/hooks/useJoin.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { join } from "@/api/AuthApi";
+import { ApiError } from "@/libs/error";
 
 import useEditProfile from "./useEditProfile";
 
@@ -30,12 +31,13 @@ export default function useJoin() {
     ...formError,
     email: 0,
     terms: false,
+    result: 0,
   };
 
-  const [error, setError] = useState<JoinFormError>(INIT_ERROR);
+  const [joinError, setJoinError] = useState<JoinFormError>(INIT_ERROR);
 
   useEffect(() => {
-    setError((prev) => ({ ...prev, ...formError }));
+    setJoinError((prev) => ({ ...prev, ...formError }));
   }, [formError]);
 
   const [agree, setAgree] = useState<Agree[]>([
@@ -82,7 +84,7 @@ export default function useJoin() {
   // 폼 유효성 검사
   const validateForm = () => {
     let isValidate = true;
-    setError(INIT_ERROR);
+    setJoinError(INIT_ERROR);
 
     // 이메일, 비밀번호 제외 form 유효성 검사
     isValidate = validateFormData();
@@ -90,23 +92,23 @@ export default function useJoin() {
     // 이메일 패턴 및 빈 문자열 검사
     const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
     if (!emailPattern.test(form.email)) {
-      setError((prev) => ({ ...prev, email: 2 }));
+      setJoinError((prev) => ({ ...prev, email: 2 }));
       isValidate = false;
     }
     if (form.email.trim().length === 0)
-      setError((prev) => ({ ...prev, email: 1 }));
+      setJoinError((prev) => ({ ...prev, email: 1 }));
 
     // 비밀번호 패턴 검사
     isValidate = validatePassword();
     if (form.password.trim().length === 0)
-      setError((prev) => ({ ...prev, password: 1 }));
+      setJoinError((prev) => ({ ...prev, password: 1 }));
 
     // 필수 약관 동의 여부 확인
     const hasDisagree = agree.find(
       (item) => item.mandatory && !item.userAgreed,
     );
     if (hasDisagree) {
-      setError((prev) => ({ ...prev, terms: true }));
+      setJoinError((prev) => ({ ...prev, terms: true }));
       isValidate = false;
     }
 
@@ -123,9 +125,16 @@ export default function useJoin() {
       try {
         await join(form);
         setIsLoading(false);
-        window.alert("회원가입이 완료되었습니다.");
+        alert("회원가입이 완료되었습니다.");
         navigate("/login");
       } catch (error) {
+        if (error instanceof ApiError && error.status === 409) {
+          // DB에 이미 존재하는 이메일인 경우
+          if (error.code === "U001")
+            setJoinError((prev) => ({ ...prev, result: 1 }));
+          // 소셜 연동 가입 회원인 경우
+          else setJoinError((prev) => ({ ...prev, result: 2 }));
+        }
         setIsLoading(false);
         console.log("Error join: ", error);
       }
@@ -137,7 +146,7 @@ export default function useJoin() {
     form,
     phone,
     agree,
-    error,
+    joinError,
     handleAddressChange,
     handleInputChange,
     handleConfirmPwChange,

--- a/src/hooks/useLeave.ts
+++ b/src/hooks/useLeave.ts
@@ -20,6 +20,7 @@ export default function useLeave() {
         openModal();
       } catch (error) {
         console.log("Error leave: ", error);
+        alert("오류가 발생했어요. 다시 시도해 주세요");
       }
       setIsLoading(false);
     }

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -14,7 +14,7 @@ export default function useLogin() {
   const INIT_ERROR = {
     email: false,
     password: false,
-    result: false,
+    result: 0,
   };
   const [loginError, setLoginError] = useState(INIT_ERROR);
 
@@ -47,8 +47,13 @@ export default function useLogin() {
         await login(email, password);
         navigate("/");
       } catch (error) {
-        if (error instanceof ApiError && error.status === 400)
-          setLoginError((prev) => ({ ...prev, result: true }));
+        if (error instanceof ApiError && error.status === 400) {
+          // 소셜 연동 가입 회원인 경우
+          if (error.code === "U004")
+            setLoginError((prev) => ({ ...prev, result: 2 }));
+          // 해당되는 사용자 정보가 없는 경우
+          else setLoginError((prev) => ({ ...prev, result: 1 }));
+        }
         console.log("Error login: ", error);
       }
       setIsLoading(false);

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -53,7 +53,7 @@ export default function useLogin() {
             setLoginError((prev) => ({ ...prev, result: 2 }));
           // 해당되는 사용자 정보가 없는 경우
           else setLoginError((prev) => ({ ...prev, result: 1 }));
-        }
+        } else alert("오류가 발생했어요. 다시 시도해 주세요");
         console.log("Error login: ", error);
       }
       setIsLoading(false);

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -12,6 +12,7 @@ export default function useLogout() {
       localStorage.removeItem("token");
     } catch (error) {
       console.log("Logout Error", error);
+      alert("오류가 발생했어요. 다시 시도해 주세요");
     }
     navigate("/", { replace: true });
   }, [navigate]);

--- a/src/hooks/useRecentReviews.ts
+++ b/src/hooks/useRecentReviews.ts
@@ -6,6 +6,7 @@ import { getRecentReviews } from "@/api/ReviewApi";
 export default function useRecentReviews() {
   const [reviews, setReviews] = useState<RecentReview[]>([]);
   const [nextKey, setNextKey] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const leftContents = reviews.filter((_, index) => index % 2 === 0);
   const rightContents = reviews.filter((_, index) => index % 2 === 1);
@@ -13,6 +14,7 @@ export default function useRecentReviews() {
   const [ref, inView] = useInView();
 
   const fetchData = async () => {
+    setIsLoading(true);
     try {
       const {
         cursorRequest: { key },
@@ -23,6 +25,7 @@ export default function useRecentReviews() {
     } catch (error) {
       console.log("Error fetching recent reviews: ", error);
     }
+    setIsLoading(false);
   };
 
   useEffect(() => {
@@ -30,5 +33,5 @@ export default function useRecentReviews() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView]);
 
-  return { leftContents, rightContents, ref };
+  return { isLoading, leftContents, rightContents, ref };
 }

--- a/src/hooks/useToggleLike.ts
+++ b/src/hooks/useToggleLike.ts
@@ -38,6 +38,7 @@ export default function useToggleLike(
       setLike((prev) => !prev);
     } catch (error) {
       console.log(error);
+      alert("오류가 발생했어요. 잠시 후 다시 시도해 주세요.");
     }
   };
 

--- a/src/hooks/useWriteReview.ts
+++ b/src/hooks/useWriteReview.ts
@@ -131,7 +131,10 @@ export default function useWriteReview({
             ...prev,
             fileUrl,
           }));
-        } else console.log("변환 실패");
+        } else {
+          console.log("변환 실패");
+          alert("변환 실패! 다시 시도해 주세요.");
+        }
       };
     }
     e.target.value = ""; // reset
@@ -176,6 +179,7 @@ export default function useWriteReview({
       navigate("/myPage/reviews");
     } catch (error) {
       console.log("Error uploading review: ", error);
+      alert("오류가 발생했어요. 잠시 후 다시 시도해 주세요.");
     }
   };
 
@@ -190,6 +194,7 @@ export default function useWriteReview({
       navigate("/myPage/reviews");
     } catch (error) {
       console.log("Error updating review: ", error);
+      alert("오류가 발생했어요. 잠시 후 다시 시도해 주세요.");
     }
   };
 
@@ -201,6 +206,7 @@ export default function useWriteReview({
       navigate("/myPage/reviews");
     } catch (error) {
       console.log("Error updating review image: ", error);
+      alert("오류가 발생했어요. 잠시 후 다시 시도해 주세요.");
     }
   };
 

--- a/src/libs/api/index.ts
+++ b/src/libs/api/index.ts
@@ -38,10 +38,10 @@ instance.interceptors.response.use(
       console.log(error, "unauthorized");
       // access token 제거
       localStorage.removeItem("token");
-      window.alert("로그인 해주세요!");
+      alert("로그인 해주세요!");
       window.location.href = "/login";
     }
-    // TODO: 서버 응답 오류 예외 처리
+
     if (error.response?.data) {
       return Promise.reject(
         new ApiError(error.response.data, error.response.status),

--- a/src/libs/api/index.ts
+++ b/src/libs/api/index.ts
@@ -43,9 +43,8 @@ instance.interceptors.response.use(
     }
 
     if (error.response?.data) {
-      return Promise.reject(
-        new ApiError(error.response.data, error.response.status),
-      );
+      const { message, code, status } = error.response.data;
+      return Promise.reject(new ApiError(message, code, status));
     }
 
     if (error.message.startsWith("timeout")) {

--- a/src/libs/error/index.ts
+++ b/src/libs/error/index.ts
@@ -1,24 +1,26 @@
 /** @description Base error class */
 export class BaseError extends Error {
-  status: number | undefined;
+  status?: number;
+  code?: string;
 
-  constructor(name: string, message: string, status?: number) {
+  constructor(name: string, message: string, code?: string, status?: number) {
     super(message);
     this.name = name;
+    this.code = code;
     this.status = status;
   }
 }
 
 /** @description 500번대 이상 서버 에러 */
 export class ServerError extends BaseError {
-  constructor(message: string, status?: number) {
-    super("ServerError", message, status);
+  constructor(message: string, code?: string, status?: number) {
+    super("ServerError", message, code, status);
   }
 }
 
 /** @description 400번대 서버 api 에러 */
 export class ApiError extends BaseError {
-  constructor(message: string, status?: number) {
-    super("ApiError", message, status);
+  constructor(message: string, code: string, status?: number) {
+    super("ApiError", message, code, status);
   }
 }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -73,7 +73,7 @@ export default function Home() {
     <Container>
       <Head />
       <VisualSection items={visualSectionMockData} />
-      {bestProducts.length !== 0 && (
+      {bestProducts && bestProducts.length !== 0 && (
         <ProductSection>
           <Title>Orday BEST</Title>
           <MoreLink to="/best">
@@ -96,7 +96,7 @@ export default function Home() {
           />
         </EventContent>
       </EventSection>
-      {newProducts.length !== 0 && (
+      {newProducts && newProducts.length !== 0 && (
         <ProductSection>
           <Title>Orday NEW</Title>
           <MoreLink to="/new">

--- a/src/routes/Join.tsx
+++ b/src/routes/Join.tsx
@@ -21,7 +21,7 @@ export default function Join() {
     form,
     phone,
     agree,
-    error,
+    joinError: error,
     handleInputChange,
     handleConfirmPwChange,
     handleSelectChange,
@@ -220,6 +220,10 @@ export default function Join() {
           </li>
         </Terms>
         {error.terms && <span>필수 약관에 동의해 주세요.</span>}
+        {error.result === 1 && <span>이미 존재하는 이메일입니다.</span>}
+        {error.result === 2 && (
+          <span>소셜 연동 가입 회원입니다. 소셜 로그인을 이용해 주세요.</span>
+        )}
         <Button type="submit">회원 가입</Button>
       </Form>
     </Container>

--- a/src/routes/Login/OAuthCallback.tsx
+++ b/src/routes/Login/OAuthCallback.tsx
@@ -5,9 +5,17 @@ import NotFound from "@/routes/NotFound";
 export default function Callback() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token");
+  const error = searchParams.get("error");
 
   // 이미 로그인 상태인 경우 홈으로 리다이렉트
   if (localStorage.getItem("token")) return <Navigate to="/" replace />;
+
+  // 이메일 가입한 회원인 경우 로그인 페이지로 리다이렉트
+  if (error) {
+    alert("이메일 가입 회원입니다! 이메일 로그인을 이용해 주세요.");
+    // <Navigate /> 사용 시 alert가 뜨기 전에 리다이렉트 됨
+    location.href = "/login";
+  }
 
   // 토큰 저장 후 홈으로 리다이렉트
   if (token) {

--- a/src/routes/Login/index.tsx
+++ b/src/routes/Login/index.tsx
@@ -60,8 +60,11 @@ export default function Login() {
             <Link to="/">비밀번호 찾기</Link>
           </Find>
         </UserActions>
-        {error.result && (
+        {error.result === 1 && (
           <span>이메일 또는 비밀번호를 다시 확인해 주세요.</span>
+        )}
+        {error.result === 2 && (
+          <span>소셜 연동 가입 회원입니다. 소셜 로그인을 이용해 주세요.</span>
         )}
         <Button type="submit">로그인</Button>
       </Form>

--- a/src/routes/Review/RecentReviews.tsx
+++ b/src/routes/Review/RecentReviews.tsx
@@ -1,16 +1,18 @@
 import styled from "styled-components";
 
 import Head from "@/components/Head";
+import Loader from "@/components/Loader";
 import ReviewCard from "@/components/ReviewCard";
 import useRecentReviews from "@/hooks/useRecentReviews";
 
 export default function RecentReviews() {
-  const { ref, leftContents, rightContents } = useRecentReviews();
+  const { isLoading, ref, leftContents, rightContents } = useRecentReviews();
 
   return (
     <Container>
       <Head title="최신 리뷰 | Orday" />
       <h1>최신 리뷰</h1>
+      {isLoading && <Loader />}
       <ReviewContainer>
         <Section>
           {leftContents.map((review) => (

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -52,6 +52,7 @@ declare interface UserInfoFormError {
 declare interface JoinFormError extends UserInfoFormError {
   email: number;
   terms: boolean;
+  result: number;
 }
 
 declare interface Category {


### PR DESCRIPTION
## 📝 개요

api 예외 응답 타입 수정 및 post/put 요청의 예외 처리 추가

## 🚀 변경사항

- POST/PUT 요청에서 오류 발생 시 사용자에게 alert 메시지 보여주도록 수정
- 최신 리뷰 목록 조회 로딩 추가
- api 예외 응답 타입 수정
- 회원가입 이메일 중복 예외 처리 추가
- 로그인 예외 처리 추가 (가입 방식과 일치하지 않는 방식의 로그인을 시도한 경우)

## 🔗 관련 이슈

#168

## ➕ 기타

가끔 로컬 및 배포 환경에서 메인 페이지에 products의 length 관련 오류가 터질 때가 있어서 조건을 추가해봤습니다.. 이걸로 해결이 되는지는 조금 더 지켜봐야 할 것 같네요. 

